### PR TITLE
deps update (security fix), lockfile and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "js-image-generator",
+  "version": "1.0.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "jpeg-js": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,22 +6,21 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository" :
-  {
-    "type" : "git",
-    "url" : "https://github.com/ashupp/js-image-generator"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ashupp/js-image-generator"
   },
   "keywords": [
     "image",
-	"images",
+    "images",
     "random",
-	"generate",
+    "generate",
     "generator",
     "dummy",
     "testdata",
-	"js",
-	"javascript",
-	"node"
+    "js",
+    "javascript",
+    "node"
   ],
   "author": "Alexander S. Hupp",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "author": "Alexander S. Hupp",
   "license": "ISC",
   "dependencies": {
-    "jpeg-js": "^0.1.2"
+    "jpeg-js": "^0.4.2"
   }
 }


### PR DESCRIPTION
Hello!

Made some security deps updates (https://github.com/dlukanin/node-raspistill/network/alert/package-lock.json/jpeg-js/open). Made some tests locally - seems that last version of jpeg-js works fine with this lib. Also added gitignore and lock files.